### PR TITLE
[#noissue] Remove invalid character in docker-compose.yml

### DIFF
--- a/pinpoint-mysql/docker-compose.yml
+++ b/pinpoint-mysql/docker-compose.yml
@@ -22,4 +22,4 @@ services:
       - MYSQL_DATABASE=${MYSQL_DATABASE}
 
     volumes:
-      - ./var/lib/mysql
+      - /var/lib/mysql


### PR DESCRIPTION
Docker does not allow relative path in anonymous volumes for container path.