### PR TITLE
Fix web container port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       - "9997"
     ports:
       - "9997:9997"
-      - "${WEB_SERVER_PORT:-8080}:${WEB_SERVER_PORT:-8080}"
+      - "${WEB_SERVER_PORT:-8080}:8080"
     environment:
       - WEB_SERVER_PORT=${WEB_SERVER_PORT}
       - SPRING_PROFILES_ACTIVE=${SPRING_PROFILES}

--- a/pinpoint-web/docker-compose.yml
+++ b/pinpoint-web/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - "9997"
     ports:
       - "9997:9997"
-      - "${WEB_SERVER_PORT:-8080}:${WEB_SERVER_PORT:-8080}"
+      - "${WEB_SERVER_PORT:-8080}:8080"
     environment:
       - WEB_SERVER_PORT=${WEB_SERVER_PORT}
       - SPRING_PROFILES_ACTIVE=${SPRING_PROFILES}


### PR DESCRIPTION
I can't access the Pinpoint-web when I set it's port to other than 8080.

Pinpoint-web container appears to be using 8080 port as default unless set aside.
Reference: https://github.com/pinpoint-apm/pinpoint/blob/357d65d00618d448c33b179bcfd9d5ca3263881f/web/src/main/resources/application.yml#L8

However, the container port is set to WEB_SERVER_PORT in the docker-compose setting. So I modified this port to 8080.
There is no problem when using the 8080 port, but using another port causes this problem.