### PR TITLE
Add hbase argument version in dockerfile

### DIFF
--- a/pinpoint-hbase/.env
+++ b/pinpoint-hbase/.env
@@ -1,5 +1,5 @@
 PINPOINT_VERSION=2.5.1
-
+HBASE_VERSION=1.2.6
 ### Pinpoint-Hbase
 
 PINPOINT_HBASE_NAME=pinpoint-hbase

--- a/pinpoint-hbase/Dockerfile
+++ b/pinpoint-hbase/Dockerfile
@@ -1,11 +1,11 @@
 FROM openjdk:8u342-slim
 
 ARG PINPOINT_VERSION=${PINPOINT_VERSION:-2.5.1}
+ARG HBASE_VERSION=${HBASE_VERSION-1.2.6}
 
 ENV HBASE_REPOSITORY=http://apache.mirrors.pair.com/hbase
 ENV HBASE_SUB_REPOSITORY=http://archive.apache.org/dist/hbase
 
-ENV HBASE_VERSION=1.2.6
 ENV BASE_DIR=/opt/hbase
 ENV HBASE_HOME=${BASE_DIR}/hbase-${HBASE_VERSION}
 


### PR DESCRIPTION
The HBase version is too outdated, and Pinpoint's HBase client is using a higher version. We want to change the version manually.