### PR TITLE
Fix old docker-compose syntax

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
   pinpoint-mysql:
     container_name: pinpoint-mysql
     image: mysql:8.0
-    restart: no
+    restart: "no"
     hostname: pinpoint-mysql
     entrypoint: > 
       sh -c "


### PR DESCRIPTION
I had an error running "docker-compose pull"

ERROR: The Compose file './docker-compose.yml' is invalid because:
services.pinpoint-mysql.restart contains an invalid type, it should be a string

And I found out there is some incorrect syntax for restart option and this is public document link
https://docs.docker.com/compose/compose-file/compose-file-v3/#restart