### PR TITLE
[#213] fix mysql cpu arch. support issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
 
   pinpoint-mysql:
     container_name: pinpoint-mysql
-    image: mysql:8.0
+    image: mysql:8.0.37-oraclelinux8
     restart: "no"
     hostname: pinpoint-mysql
     entrypoint: > 


### PR DESCRIPTION
Fix container run error: "Fatal glibc error: CPU does not support x86-64-v2"
Reference: https://github.com/docker-library/mysql/issues/1055